### PR TITLE
Rendered current user messages

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -5,6 +5,8 @@ import { AnimalProvider } from "./animal/AnimalProvider"
 import { AnimalEnergyLevelProvider } from "./animalEnergyLevel/AnimalEnergyLevelProvider"
 import { AnimalGenderProvider } from "./animalGender/AnimalGenderProvider"
 import { AnimalSizeProvider } from "./animalSize/AnimalSizeProvider"
+import { MessageList } from "./directMessage/DirectMessageList"
+import { DirectMessageProvider } from "./directMessage/DirectMessageProvider"
 import { LocationDetail } from "./location/LocationDetail"
 import { LocationFriends } from "./location/LocationFriends"
 import { LocationList } from "./location/LocationList"
@@ -33,8 +35,7 @@ export const ApplicationViews = () => {
                 </LocationProvider>
             </UserProvider>
 
-            {/* Render Animal Forms */}
-            
+            {/* Render Animal Forms */}   
             <AnimalEnergyLevelProvider>
                 <AnimalGenderProvider>
                     <AnimalSizeProvider>
@@ -68,6 +69,13 @@ export const ApplicationViews = () => {
                     </Route>
                 </UserProvider>
             </LocationProvider>
+
+            {/* Render Direct Messages */}
+            <DirectMessageProvider>
+                    <Route exact path="/messages">
+                        <MessageList />
+                    </Route>
+            </DirectMessageProvider>
         </>
     )
 }

--- a/src/components/directMessage/DirectMessage.css
+++ b/src/components/directMessage/DirectMessage.css
@@ -1,0 +1,31 @@
+.messages-title {
+    text-align: center;
+}
+
+.messagesParent-flex {
+    display: flex;
+    justify-content: center;
+}
+
+.messages {
+    display: flex;
+    flex-direction: column;
+    width: 75%;
+}
+
+.message {
+    flex-basis: 25%;
+    margin: 1em;
+    padding: 1em;
+    background: linear-gradient(90deg, rgba(242, 242, 242, 0.324) 0%, rgba(235, 235, 235, 0.447) 80%);
+    box-shadow: 0px 0px 6px rgb(212, 212, 212);
+    text-align: center;
+    border-radius: 20px;
+}
+
+.btn-delete-flex {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 1rem;
+    margin-right: 2rem;
+}

--- a/src/components/directMessage/DirectMessageList.js
+++ b/src/components/directMessage/DirectMessageList.js
@@ -3,5 +3,43 @@ import { DirectMessageContext } from "./DirectMessageProvider"
 import "./DirectMessage.css"
 
 
-export const 
-DirectMessageContext
+export const MessageList = () => {
+    const { messages, getMessages, removeMessage } = useContext(DirectMessageContext)
+    const userId = parseInt(localStorage.getItem("barkbook_user"))
+
+    useEffect(() => {
+        getMessages()
+    }, [])
+
+    
+    const userMessages = messages.filter(message => message.recipientId === userId)
+
+    
+
+    return (
+        <>
+            <h1 className="messages-title">Current Messages</h1>
+
+            <div className="messagesParent-flex">
+                <div className="messages">
+                    {
+                        userMessages.map(message => 
+                            <>
+                                <div className="message" key={message.id}>
+                                    <div className="message__subject">From: { message.user.name } </div>
+                                    <div className="message__subject">Subject: { message.subject } </div>
+                                    <div className="message__subject">Date: { message.date } </div>
+                                    <div className="message__message">Message: { message.message } </div>
+                                    <div className="btn-delete-flex">
+                                        <button className="btn btn-delete" onClick={() => {
+                                            removeMessage(message.id)
+                                        }}>Delete Message</button>
+                                    </div>
+                                </div>
+                            </>                            
+                        )}  
+                </div>
+            </div>
+        </>
+    )
+}

--- a/src/components/directMessage/DirectMessageList.js
+++ b/src/components/directMessage/DirectMessageList.js
@@ -1,0 +1,7 @@
+import React, { useState, useEffect, useContext } from "react"
+import { DirectMessageContext } from "./DirectMessageProvider"
+import "./DirectMessage.css"
+
+
+export const 
+DirectMessageContext

--- a/src/components/directMessage/DirectMessageProvider.js
+++ b/src/components/directMessage/DirectMessageProvider.js
@@ -12,11 +12,18 @@ export const DirectMessageProvider = (props) => {
         .then((data) => setMessages(data))
     }
 
+    const removeMessage = messageId => {
+        return fetch(`http://localhost:8088/directMessages/${messageId}`, {
+            method: "DELETE"
+        })
+        .then(getMessages)
+    }
+
 
     return (
         <DirectMessageContext.Provider value= {
             {
-                messages, getMessages
+                messages, getMessages, removeMessage
             }
         }>
             {props.children}

--- a/src/components/directMessage/DirectMessageProvider.js
+++ b/src/components/directMessage/DirectMessageProvider.js
@@ -1,0 +1,25 @@
+import React, { useState, createContext } from "react"
+
+export const DirectMessageContext = createContext()
+
+
+export const DirectMessageProvider = (props) => {
+    const [messages, setMessages] = useState([])
+
+    const getMessages = () => {
+        return fetch("http://localhost:8088/directMessages?_expand=user")
+        .then(res => res.json())
+        .then((data) => setMessages(data))
+    }
+
+
+    return (
+        <DirectMessageContext.Provider value= {
+            {
+                messages, getMessages
+            }
+        }>
+            {props.children}
+        </DirectMessageContext.Provider>
+    )
+}


### PR DESCRIPTION
Added routing to get to user messages. Now displays current users direct message list with message info. Delete button added with the functionality of deleting individual message.

## Steps to Test
1. get fetch --all
2. git checkout render-user-messages
3. Refresh page
4. Click mail icon, this takes to you the direct messages list for the current user. You should see a list of messages with delete buttons. Click a delete button and confirm a delete fetch request.