### PR TITLE
Enabled different styling for messages 

### DIFF
--- a/src/components/directMessage/DirectMessage.css
+++ b/src/components/directMessage/DirectMessage.css
@@ -2,6 +2,11 @@
     text-align: center;
 }
 
+.no-messages-title {
+    margin-top: 8rem;
+    text-align: center;
+}
+
 .messagesParent-flex {
     display: flex;
     justify-content: center;
@@ -10,7 +15,7 @@
 .messages {
     display: flex;
     flex-direction: column;
-    width: 75%;
+    flex-basis: 40%;
 }
 
 .message {
@@ -19,8 +24,25 @@
     padding: 1em;
     background: linear-gradient(90deg, rgba(242, 242, 242, 0.324) 0%, rgba(235, 235, 235, 0.447) 80%);
     box-shadow: 0px 0px 6px rgb(212, 212, 212);
-    text-align: center;
     border-radius: 20px;
+}
+   
+
+.message__detail-flex {
+    display: flex;
+    justify-content: space-between;
+}
+
+.readTrue {
+   font-weight: light; 
+}
+
+.readFalse {
+    background: transparent;
+    background: linear-gradient(90deg, #8860D0 20%, #5680E9 90%);
+    box-shadow: 0px 0px 10px rgb(167, 167, 167);
+    color: white;
+    font-weight: bolder;
 }
 
 .btn-delete-flex {
@@ -28,6 +50,10 @@
     justify-content: flex-end;
     margin-top: 1rem;
     margin-right: 2rem;
+}
+
+.btn-reply {
+    margin-right: 3rem;
 }
 
 .form-flex {

--- a/src/components/directMessage/DirectMessageList.js
+++ b/src/components/directMessage/DirectMessageList.js
@@ -1,18 +1,23 @@
 import React, { useEffect, useContext } from "react"
 import { DirectMessageContext } from "./DirectMessageProvider"
+import { useHistory } from 'react-router-dom'
 import "./DirectMessage.css"
 
 
 export const MessageList = () => {
     const { messages, getMessages, removeMessage } = useContext(DirectMessageContext)
     const userId = parseInt(localStorage.getItem("barkbook_user"))
+    const history = useHistory()
 
     useEffect(() => {
         getMessages()
     }, [])
 
+    const sortedMessages = messages.sort((a, b) => {
+        return b.date - a.date
+    })
+    const userMessages = sortedMessages.filter(message => message.recipientId === userId)
     
-    const userMessages = messages.filter(message => message.recipientId === userId)
 
     return (
         <>
@@ -26,18 +31,25 @@ export const MessageList = () => {
                         {
                             userMessages.map(message => 
                             <>
-                                <div className="message" key={message.id}>
-                                    <div className="message__subject"><b>From:</b> { message.user.name } </div>
-                                    <div className="message__subject"><b>Subject:</b> { message.subject } </div>
-                                    <div className="message__subject"><b>Sent:</b>
-                                        {
-                                            new Intl.DateTimeFormat('en-US', {year: 'numeric',
-                                            month: '2-digit', day: '2-digit', hour: '2-digit',
-                                            minute: '2-digit', second: '2-digit'}).format(message.date)
-                                        }
-                                    </div>
-                                    <div className="message__message"><b>Message:</b> { message.message } </div>
+                                <div className={ `message ${message.read ? "readTrue" : "readFalse"}`} key={message.id}>
+                                    <h2 className="message__detail"><b>Subject:</b> { message.subject } </h2>
+                                    
+                                    <h3 className="message__detail-flex">
+                                        <div className="message__detail"><b>From:</b> { message.user.name } </div>
+                                        <div className="message__detail"><b>Received:</b>
+                                            {
+                                                new Intl.DateTimeFormat('en-US', {year: 'numeric',
+                                                month: '2-digit', day: '2-digit', hour: '2-digit',
+                                                minute: '2-digit', second: '2-digit'}).format(message.date)
+                                            }
+                                        </div>
+                                    </h3>
+                                    
+                                    <div className="message__detail"><b>Message:</b> { message.message } </div>
                                     <div className="btn-delete-flex">
+                                        <button className="btn btn-reply" onClick={() => {
+                                            history.push(`/messages/reply/${message.id}`)
+                                        }}>Reply to Message</button>
                                         <button className="btn btn-delete" onClick={() => {
                                             removeMessage(message.id)
                                         }}>Delete Message</button>
@@ -47,9 +59,10 @@ export const MessageList = () => {
                         )}
                     </> 
                     : 
-                    <><h2>You Currently Have No Messages</h2></>}
+                    <><h2 className="no-messages-title">You Currently Have No Messages</h2></>}
                 </div>
             </div>
         </>
     )
 }
+

--- a/src/components/park/ParkList.js
+++ b/src/components/park/ParkList.js
@@ -14,10 +14,15 @@ export const ParkList = () => {
     }, [])
 
     useEffect(() => {
+        setLocationName("all")
+    }, [])
+
+    
+    useEffect(() => {
         locationName === "all" ? setFilteredParks(parks) : setFilteredParks(parks.filter(park => park.location.name === locationName))
     }, [locationName])
-
-   
+    
+    
 
     return (
         <>


### PR DESCRIPTION
Messages whose key "read" is false has different styling than messages that have been read - as in truthy. A reply button was also added and redirects URL to new page with the message id attached.

## Steps to Test
1. git fetch  --all
2. git checkout message-styling
3. refresh page
4. Verify the messages have different styling for user 2
5. Verify messages are sorted from newest to oldest
6. Verify reply button redirects URL 