### PR TITLE
Added replying to direct message functionality 

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -17,6 +17,8 @@ import { UserProfile } from "./user/UserProfile"
 import { UserProvider } from "./user/UserProvider"
 import { ParkProvider } from "./park/ParkProvider"
 import { ParkList } from "./park/ParkList"
+import { DirectMessage } from "./directMessage/DirectMessage"
+
 
 
 export const ApplicationViews = () => {
@@ -84,6 +86,10 @@ export const ApplicationViews = () => {
             <DirectMessageProvider>
                     <Route exact path="/messages">
                         <MessageList />
+                    </Route>
+
+                    <Route exact path="/messages/reply/:messageId(\d+)">
+                        <DirectMessage />
                     </Route>
             </DirectMessageProvider>
 

--- a/src/components/directMessage/DirectMessage.css
+++ b/src/components/directMessage/DirectMessage.css
@@ -56,15 +56,19 @@
     margin-right: 3rem;
 }
 
+.btn-send {
+    margin: 1.5rem 0;
+}
+
 .form-flex {
     display: flex;
     flex-direction: column;
     align-items: center;
 }
 
-.user-form {
+.createMessage-form {
     display: block;
-    width: 50%;
+    width: 35%;
     padding: .375rem .75rem;
     font-size: 1rem;
     font-weight: 400;
@@ -82,4 +86,28 @@
 .btn-flex {
     display: flex;
     justify-content: center;
+}
+
+.reply-flex {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+.reply-form {
+    display: block;
+    width: 35%;
+    padding: .375rem .75rem;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #495057;
+    background-color: #fff;
+    background-clip: padding-box;
+    border: 1px solid #ced4da;
+    box-shadow: 0px 0px 6px rgb(212, 212, 212);
+    border-radius: 20px;
+    -webkit-transition: border-color .15s ease-in-out,box-shadow .15s ease-in-out;
+    transition: border-color .15s ease-in-out,box-shadow .15s ease-in-out;
 }

--- a/src/components/directMessage/DirectMessage.js
+++ b/src/components/directMessage/DirectMessage.js
@@ -1,0 +1,41 @@
+import React, { useState, useEffect, useContext } from "react"
+import { DirectMessageContext } from "./DirectMessageProvider"
+import { DirectMessageReply } from "./DirectMessageReply"
+import { useParams } from "react-router-dom"
+import "./DirectMessage.css"
+
+
+export const DirectMessage = () => {
+    const { getMessageById } = useContext(DirectMessageContext)
+    const [ message, setMessage ] = useState({ user: {} })
+    const { messageId } = useParams()
+
+  
+    useEffect(() => {
+        getMessageById(messageId).then(message => {
+            setMessage(message)
+        })
+    }, [messageId])
+
+    
+    return (
+        <>
+        <h1 className="title">Reply to {message.user.name}  </h1>
+        <section className="reply-flex">
+            <div className="reply-form">
+                <div><b>From:</b> {message.user.name} </div>
+                <div><b>Date:</b> {
+                                    new Intl.DateTimeFormat('en-US', {year: 'numeric',
+                                    month: '2-digit', day: '2-digit', hour: 'numeric',
+                                    minute: '2-digit', second: '2-digit'}).format(message.date)
+                                    }
+                </div>
+                <div><b>Subject:</b> {message.subject} </div>
+                <div><b>Message:</b> {message.message}</div>
+            </div>
+        </section>
+            <br></br>
+            <DirectMessageReply userId={message.userId} />
+        </>
+    )
+}

--- a/src/components/directMessage/DirectMessageList.js
+++ b/src/components/directMessage/DirectMessageList.js
@@ -5,7 +5,7 @@ import "./DirectMessage.css"
 
 
 export const MessageList = () => {
-    const { messages, getMessages, removeMessage } = useContext(DirectMessageContext)
+    const { messages, getMessages, removeMessage, updateMessage } = useContext(DirectMessageContext)
     const userId = parseInt(localStorage.getItem("barkbook_user"))
     const history = useHistory()
 
@@ -17,6 +17,21 @@ export const MessageList = () => {
         return b.date - a.date
     })
     const userMessages = sortedMessages.filter(message => message.recipientId === userId)
+    
+    
+    const setMessageToRead = (message) => {
+        updateMessage({
+            id: message.id,
+            subject: message.subject,
+            message: message.message,
+            read: true,
+            recipientId: message.recipientId,
+            userId: message.userId,
+            date: message.date
+        })
+    }
+    
+
     
 
     return (
@@ -30,16 +45,15 @@ export const MessageList = () => {
                     <>
                         {
                             userMessages.map(message => 
-                            <>
+                            <> 
                                 <div className={ `message ${message.read ? "readTrue" : "readFalse"}`} key={message.id}>
                                     <h2 className="message__detail"><b>Subject:</b> { message.subject } </h2>
                                     
                                     <h3 className="message__detail-flex">
                                         <div className="message__detail"><b>From:</b> { message.user.name } </div>
-                                        <div className="message__detail"><b>Received:</b>
-                                            {
+                                        <div className="message__detail"><b>Received:</b> {
                                                 new Intl.DateTimeFormat('en-US', {year: 'numeric',
-                                                month: '2-digit', day: '2-digit', hour: '2-digit',
+                                                month: '2-digit', day: '2-digit', hour: 'numeric',
                                                 minute: '2-digit', second: '2-digit'}).format(message.date)
                                             }
                                         </div>
@@ -49,6 +63,7 @@ export const MessageList = () => {
                                     <div className="btn-delete-flex">
                                         <button className="btn btn-reply" onClick={() => {
                                             history.push(`/messages/reply/${message.id}`)
+                                            setMessageToRead(message)
                                         }}>Reply to Message</button>
                                         <button className="btn btn-delete" onClick={() => {
                                             removeMessage(message.id)

--- a/src/components/directMessage/DirectMessageProvider.js
+++ b/src/components/directMessage/DirectMessageProvider.js
@@ -24,6 +24,23 @@ export const DirectMessageProvider = (props) => {
         .then(getMessages)
     }
 
+    const getMessageById = messageId => {
+        return fetch(`http://localhost:8088/directMessages/${messageId}?_expand=user`)
+        .then(res => res.json())
+    }
+
+
+    const updateMessage = message => {
+        return fetch(`http://localhost:8088/directMessages/${message.id}`, {
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(message)
+        })
+        .then(getMessages)
+    }
+
     const removeMessage = messageId => {
         return fetch(`http://localhost:8088/directMessages/${messageId}`, {
             method: "DELETE"
@@ -35,7 +52,7 @@ export const DirectMessageProvider = (props) => {
     return (
         <DirectMessageContext.Provider value= {
             {
-                messages, getMessages, removeMessage, addMessage
+                messages, getMessages, removeMessage, addMessage, getMessageById, updateMessage
             }
         }>
             {props.children}

--- a/src/components/directMessage/DirectMessageReply.js
+++ b/src/components/directMessage/DirectMessageReply.js
@@ -1,37 +1,23 @@
-import React, { useContext, useEffect, useState } from "react"
-import { UserContext } from "../user/UserProvider"
+import React, { useEffect, useContext, useState } from "react"
 import { DirectMessageContext } from "./DirectMessageProvider"
-import { useHistory, useParams } from "react-router-dom"
+import { useHistory } from 'react-router-dom'
 import "./DirectMessage.css"
 
 
-
-
-export const DirectMessageForm = () => {
-    const { getUserById } = useContext(UserContext)
-    const { addMessage } = useContext(DirectMessageContext)
-    const [user, setUser] = useState({ animals: [], location: {}})
+export const DirectMessageReply = ({ userId }) => {
+    const { getMessages, updateMessage, addMessage } = useContext(DirectMessageContext)
     const senderId = parseInt(localStorage.getItem("barkbook_user"))
-    const {userId} = useParams()
     const history = useHistory()
-
+    
     const [message, setMessage] = useState({
         subject: "",
         message: "",
         read: false,
         recipientId: 0,
-        userId: 0,
+        userId: senderId,
         date: Date.now()
     })
-    
 
-    useEffect(() => {
-        getUserById(userId).then((user) => 
-        setUser(user))
-    }, [])
-
-    //when a field changes, update state. The return will re-render and display based on the values in state
-    //Controlled component
     const handleInputChange = (event) => {
         const newMessage = { ...message }
         newMessage[event.target.name] = event.target.value
@@ -50,20 +36,25 @@ export const DirectMessageForm = () => {
             subject: message.subject,
             message: message.message,
             read: false,
-            recipientId: parseInt(userId),
+            recipientId: userId,
             userId: senderId,
             date: Date.now()
           }
           addMessage(newMessage)
-            .then(() => history.push("/locations"))
+            .then(() => history.push("/messages"))
         }
       }
+ 
+
+    useEffect(() => {
+        getMessages()
+    }, [])
+
 
     return (
         <>
             <div className="form-flex">
-                <h1 className="title">Create a Message to {user.name}</h1>
-                <form className="createMessage-form">
+                <form className="reply-form">
                 <fieldset>
                     <div className="form-group">
                     <label htmlFor="userName">Subject:</label>

--- a/src/components/user/UserForm.js
+++ b/src/components/user/UserForm.js
@@ -23,7 +23,6 @@ export const UserForm = () => {
         const updateUser = { ...user }
         updateUser[event.target.name] = event.target.value
         setUser(updateUser)
-        console.log("Change noticed")
     }
 
 

--- a/src/components/user/UserProfile.css
+++ b/src/components/user/UserProfile.css
@@ -10,7 +10,7 @@
 
 .profileCards__flex {
     display: flex;
-    justify-content: space-evenly;
+    justify-content: center;
     flex-wrap: wrap;
     flex-basis: 85%;
 }
@@ -23,7 +23,7 @@
     height: 600px;
     box-shadow: 0px 0px 6px rgb(212, 212, 212);
     border-radius: 20px;
-    
+    margin: 0 1.5rem;
 }
 
 .profileCards__animal {
@@ -34,7 +34,7 @@
     height: 600px;
     box-shadow: 0px 0px 6px rgb(212, 212, 212);
     border-radius: 20px;
-    
+    margin: 0 1.5rem;
 }
 
 .avatar {


### PR DESCRIPTION
Users can now click the reply button and be taken to a message form that renders the message they're replying to. They can create a new message and hit send and be redirected to their message list. When a user clicks on reply, that message's "read" key-value pair is changed from false to true, which will render a different CSS style.

## Steps to Test
1. git fetch --all
2. git checkout directMessage-reply
3. refresh page
4. Verify clicking on reply takes you to new message form with the rendered message above that you're replying to
5. New message gets sent and you get redirected to the message list
6. The message you replied to should now be rendered with different CSS styling